### PR TITLE
Fix typo in command line options

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -67,7 +67,7 @@ few new command line parameters.
 ``setup.py clean --dist``
    Removes directories that the various *dist* commands produce.
 
-``setup.py clean --egg``
+``setup.py clean --eggs``
    Removes *.egg* and *.egg-info* directories.
 
 ``setup.py clean --environment``


### PR DESCRIPTION
The '--egg' option described in the README should be '--eggs'. If you use '--egg' as the README describes, you get an error because there are two command line options that start with '--egg': '--eggs' and '--egg-base'.
