### PR TITLE
Remove build directories with `--build`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
 - '3.5'
 - '3.6'
 - '3.7'
+- '3.8'
 - pypy
 - pypy3
 install:

--- a/README.rst
+++ b/README.rst
@@ -78,6 +78,9 @@ Usage
 Once the extension is installed, the ``clean`` command will accept a
 few new command line parameters.
 
+``setup.py clean --build``
+   Removes directories that various *build* commands produce.
+
 ``setup.py clean --dist``
    Removes directories that the various *dist* commands produce.
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,7 +1,7 @@
 Changelog
 =========
 
-* Next release
+* 1.1.2 (23-Nov-2019)
 
   - Add support for *--build* (`#17`_)
   - Clean up sphinx generated directories with *--build* (`#6`_)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,7 @@ Changelog
 * Next release
 
   - Add support for *--build* (`#17`_)
+  - Clean up sphinx generated directories with *--build* (`#6`_)
 
 * 1.1.1 (07-May-2019)
 
@@ -29,4 +30,5 @@ Changelog
   - Support removal of distribution directories.
 
 
+.. _#6: https://github.com/dave-shawley/setupext-janitor/issues/6
 .. _#17: https://github.com/dave-shawley/setupext-janitor/issues/17

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+* Next release
+
+  - Add support for *--build* (`#17`_)
+
 * 1.1.1 (07-May-2019)
 
   - Fix ``Requires-Python`` metadata.
@@ -23,3 +27,6 @@ Changelog
   - Support removal of .egg-info and .egg directories.
   - Add support for *--dry-run*
   - Support removal of distribution directories.
+
+
+.. _#17: https://github.com/dave-shawley/setupext-janitor/issues/17

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,7 @@ Changelog
 
   - Add support for *--build* (`#17`_)
   - Clean up sphinx generated directories with *--build* (`#6`_)
+  - Add 3.8 into the test matrix.
 
 * 1.1.1 (07-May-2019)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,12 +4,15 @@ universal = 1
 [build_sphinx]
 all-files = 1
 
+[coverage:report]
+show_missing = 1
+
 [nosetests]
 nocapture = 1
 verbose = 1
 stop = 1
 with-coverage = 1
-cover-package = setupext,tests
+cover-package = setupext_janitor
 cover-erase = 1
 cover-branches = 1
 

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ setuptools.setup(
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
         'Framework :: Setuptools Plugin',
         'Development Status :: 5 - Production/Stable',
     ],

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ setuptools.setup(
         'dev': [
             'coverage==4.5.3',
             'flake8==3.7.7',
+            'mock==1.0.1; python_version<"3"',
             'nose==1.3.7',
             'sphinx==1.8.5',
             'sphinx-rtd-theme==0.4.3',

--- a/setupext_janitor/__init__.py
+++ b/setupext_janitor/__init__.py
@@ -1,2 +1,2 @@
-version_info = (1, 1, 1)
+version_info = (1, 1, 2)
 version = '.'.join(str(v) for v in version_info)

--- a/setupext_janitor/janitor.py
+++ b/setupext_janitor/janitor.py
@@ -76,7 +76,8 @@ class CleanCommand(_CleanCommand):
             dir_names.update(_gather_attributes(
                 self.distribution,
                 lambda cmd_name: cmd_name.startswith('build'),
-                'build_base', 'build_clib', 'build_lib', 'build_temp'))
+                'build_base', 'build_clib', 'build_dir', 'build_lib',
+                'build_temp'))
 
         if self.dist:
             dir_names.update(_gather_attributes(

--- a/tests.py
+++ b/tests.py
@@ -11,6 +11,8 @@ try:
 except ImportError:
     import mock
 
+import sphinx.setup_command
+
 from setupext_janitor import janitor
 
 
@@ -314,6 +316,15 @@ class BuildCleanupTests(DirectoryCleanupMixin, unittest.TestCase):
         self.assert_path_exists('build')
         run_setup('clean', '--build')
         self.assert_path_does_not_exist('build')
+
+    def test_that_sphinx_build_dirs_are_removed(self):
+        sphinx_build_dir = self.mkdirs('sphinx-build-dir')[0]
+        run_setup(
+            'build_sphinx', '--build-dir', sphinx_build_dir,
+            'clean', '--build',
+            cmdclass={'build_sphinx': sphinx.setup_command.BuildDoc},
+        )
+        self.assert_path_does_not_exist(sphinx_build_dir)
 
 
 class RemoveAllTests(DirectoryCleanupMixin, unittest.TestCase):

--- a/tests.py
+++ b/tests.py
@@ -296,6 +296,26 @@ class PycacheCleanupTests(DirectoryCleanupMixin, unittest.TestCase):
             self.assert_path_does_not_exist(cache_dir)
 
 
+class BuildCleanupTests(DirectoryCleanupMixin, unittest.TestCase):
+
+    def setUp(self):
+        super(BuildCleanupTests, self).setUp()
+        self.test_root = self.create_directory('test-root')
+        starting_dir = os.curdir
+        self.addCleanup(os.chdir, starting_dir)
+        os.chdir(self.test_root)
+
+    def test_that_build_directory_is_removed(self):
+        os.mkdir('build')
+        # the core clean action will remove the build directory if AND
+        # ONLY IF it is empty
+        with open(os.path.join('build', 'stamp'), 'w') as f:
+            f.write('need a file here')
+        self.assert_path_exists('build')
+        run_setup('clean', '--build')
+        self.assert_path_does_not_exist('build')
+
+
 class RemoveAllTests(DirectoryCleanupMixin, unittest.TestCase):
 
     @classmethod

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ envlist = py27,py35,py36,py37
 toxworkdir = {toxinidir}/build/tox
 
 [testenv]
-deps = -rtest-requirements.txt
+deps = .[dev]
 commands = {envbindir}/nosetests
 
 [testenv:py27]

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py35,py36,py37
+envlist = py27,py35,py36,py37,py38
 toxworkdir = {toxinidir}/build/tox
 
 [testenv]


### PR DESCRIPTION
This also takes care of the sphinx generated docs (#6) since sphinx registers them as a build directory... at least, I defined "registration" that way (see 5c84caa).